### PR TITLE
Deal with codes that are also relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## :package: [0.10.0](https://pypi.org/project/uk-geo-utils/0.10.0/) - 2020-08-25
+
+* Fixed issue where ForeignKey relationships would return the relation not
+ the code when using `get_code`.
+
+
 ## :package: [0.9.0](https://pypi.org/project/uk-geo-utils/0.9.0/) - 2019-02-06
 
 * Add pre-processing script for Addressbase Plus: `clean_addressbase_plus`

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def _get_description():
 
 setup(
     name="uk_geo_utils",
-    version="0.9.0",
+    version="0.10.0",
     author="chris48s",
     license="MIT",
     url="https://github.com/DemocracyClub/uk-geo-utils",

--- a/uk_geo_utils/geocoders.py
+++ b/uk_geo_utils/geocoders.py
@@ -104,7 +104,7 @@ class AddressBaseGeocoder(BaseGeocoder):
 
     def get_code(self, code_type, uprn=None, strict=False):
         # check the code_type field exists on our model
-        self.onsud_model._meta.get_field(code_type)
+        code_type_field = self.onsud_model._meta.get_field(code_type)
 
         if uprn:
             self._addresses.get_cached(uprn)
@@ -127,7 +127,7 @@ class AddressBaseGeocoder(BaseGeocoder):
                 # if not strict, ignore this condition
                 pass
 
-        codes = set([getattr(u, code_type) for u in self._uprns])
+        codes = set([getattr(u, code_type_field.attname) for u in self._uprns])
         if len(codes) == 1:
             # all the uprns supplied are in the same area
             return list(codes)[0]


### PR DESCRIPTION
Using the fields's `attrname` ensures a code is already returned, rather than the related model

Fixes #15

