### PR TITLE
fix help text for import_cleaned_addresses command

### DIFF
--- a/uk_geo_utils/management/commands/import_cleaned_addresses.py
+++ b/uk_geo_utils/management/commands/import_cleaned_addresses.py
@@ -7,9 +7,9 @@ from uk_geo_utils.helpers import get_address_model
 
 class Command(BaseCommand):
     help = (
-        "Deletes all data in Address model AND any related tables,",
-        "and replaces Address model data with that in the cleaned AddressBase CSVs.",
-        "Data in related tables will need to be imported/rebuilt seperately",
+        "Deletes all data in Address model AND any related tables,"
+        "and replaces Address model data with that in the cleaned AddressBase CSVs."
+        "Data in related tables will need to be imported/rebuilt seperately"
     )
 
     def add_arguments(self, parser):


### PR DESCRIPTION
Running `./manage.py import_cleaned_addresses --help` currently throws `TypeError: expected string or bytes-like object` because `help` is a tuple not a string