### PR TITLE
Create temp tables unlogged

### DIFF
--- a/uk_geo_utils/base_importer.py
+++ b/uk_geo_utils/base_importer.py
@@ -244,7 +244,7 @@ class BaseImporter(BaseCommand):
         )
         self.cursor.execute(f"DROP TABLE IF EXISTS {self.temp_table_name};")
         self.cursor.execute(
-            f"CREATE TABLE {self.temp_table_name} AS SELECT * FROM {self.table_name} LIMIT 0;"
+            f"CREATE UNLOGGED TABLE {self.temp_table_name} AS SELECT * FROM {self.table_name} LIMIT 0;"
         )
 
     def drop_old_table(self):


### PR DESCRIPTION
This stops anything to do with the table being written to the WAL or being replicated. This is good because we have publication set to all tables on WDIV and so when we created the temp table it would try and replicate it, then hit the following error:

> OperationalError: cannot update table "uk_geo_utils_onspd_temp"
> because it does not have a replica identity and publishes updates
> HINT:  To enable updating the table, set REPLICA IDENTITY using ALTER TABLE.

This stops that happening.
