### PR TITLE
Alter temp table replica identity during import.

### DIFF
--- a/uk_geo_utils/base_importer.py
+++ b/uk_geo_utils/base_importer.py
@@ -329,7 +329,9 @@ class BaseImporter(BaseCommand):
             )
 
         db_name = options["database"]
-        self.cursor = connections[db_name].cursor()
+        connection = connections[db_name]
+        self.cursor = connection.cursor()
+        self.stdout.write(f"Connected to: {connection.settings_dict['NAME']} @ {connection.settings_dict['HOST'] if connection.settings_dict['HOST'] else 'localhost'}")
 
         self.get_data_path(options)
 


### PR DESCRIPTION
The first problem this fixes is the non replication caused by creating the temp tables as unlogged.
They carried this with them over the rename, meaning when a new instance was spun up it wouldn't replicate these tables.

The solution I've come to is setting the temp tables 'replica identity' to `FULL` for the the data loading phase, and then back to 'DEFAULT' (which uses the pk) before the name change transaction.
However this seems to break replication fairly reliably. On The RDS `select * from pg_replication_slots;` returns a slot with `active: f`, ``wal_status: lost` and `conflicting: t`.
So even with this 'fix' it will be necessary to cycle the instances after an addressbase update to get the local dbs in sync with the RDS. Thankfully this seems to do the trick.

---------------------------

I've tested this on WDIV Dev by sshing into the instance and doing the following:

* uninstall uk-geo-utils and reinstall this branch:
```shell
pip uninstall uk-geo-utils
pip install 'uk-geo-utils @ git+https://github.com/DemocracyClub/uk-geo-utils@hotfix/import-replication-issue'
```

* reimport onspd and addressbase on the principal db:
```shell
time ./manage.py update_addressbase --database principal \
        --addressbase-s3-uri='s3://pollingstations.private.data/addressbase/2024-08-06/addressbase_cleaned/AddressBasePlus_FULL_2024-08-06_addressbase_cleaned.csv' \
        --uprntocouncil-s3-uri='s3://pollingstations.private.data/addressbase/2024-08-06/uprn-to-council/AddressBasePlus_FULL_2024-08-06_uprn-to-councils.csv'
```
and
```shell
time python manage.py import_onspd  --url https://s3.eu-west-2.amazonaws.com/pollingstations.public.data/ons/onspd/ONSPD_AUG_2024.zip --database principal
```

* Before and after these commands I confirmed that `relpersistence` for the relevant tables (and their indexes) changed from `u` to `p` on RDS. After the first time this didn't revert.
```sql
select relpersistence, relname from pg_class where relname like 'uk_geo_utils%' or relname like 'address%';
```

* Before and after the commands I checked `relreplident` changed from full to default. After the first time this didn't revert:

```sql
SELECT oid::regclass, CASE relreplident
          WHEN 'd' THEN 'default'
          WHEN 'n' THEN 'nothing'
          WHEN 'f' THEN 'full'
          WHEN 'i' THEN 'index'
       END AS replica_identity
FROM pg_class
WHERE oid::regclass::text like 'uk_geo%' or oid::regclass::text like 'address%';
```

I then cycled the instances by bumping the instance count (couldn't make ASG instance refresh play ball) and terminating the old instance.
The new instance that came up had data in the local db and the rds had active, happy replication slots. I checked replication by deleting some rows and confirming they carried over to the instances.


------------------------------

I don't have great mental model for what's going on here. I think `self.cursor.execute(f"ALTER TABLE {self.temp_table_name} REPLICA IDENTITY FULL;")` just tells the wal files to use the whole row as the identity when recording changes to the WAL.
Clearly the process of renaming tables breaks the chain of the WAL in someway.

I'm not sure what the 'right' thing to do here is.